### PR TITLE
feat(analytics): implement BQ13 ApplicationStatusDistributionScreen (#39)

### DIFF
--- a/flutter_application_goatly/lib/data/settings_state.dart
+++ b/flutter_application_goatly/lib/data/settings_state.dart
@@ -236,6 +236,13 @@ class SettingsState extends ChangeNotifier with WidgetsBindingObserver {
         'high_gpa_pct': '% con GPA ≥ 4.0',
         'high_gpa_count': 'Con GPA ≥ 4.0',
         'no_high_gpa_data': 'No hay datos de GPA alto disponibles',
+        // ── BQ13 (David Hernandez) ─ Status Distribution ──
+        'status_distribution': 'Distribución de Estados',
+        'status_distribution_title': 'Distribución de Estados (Semestre)',
+        'status_distribution_subtitle': '¿Cómo se distribuyen las solicitudes entre pendiente, aceptada y rechazada este semestre?',
+        'per_offer_breakdown': 'Desglose por oferta',
+        'no_status_data': 'No hay datos de aplicaciones para este semestre',
+        'status_offline_banner': 'Sin conexión — mostrando datos guardados',
         // ── Form fields & hints ──
         'offer_details': 'Detalles de la oferta',
         'offer_subtitle': 'Completa los campos para publicar tu nueva solicitud.',
@@ -598,6 +605,13 @@ class SettingsState extends ChangeNotifier with WidgetsBindingObserver {
         'high_gpa_pct': '% with GPA ≥ 4.0',
         'high_gpa_count': 'With GPA ≥ 4.0',
         'no_high_gpa_data': 'No high-GPA data available',
+        // ── BQ13 (David Hernandez) ─ Status Distribution ──
+        'status_distribution': 'Status Distribution',
+        'status_distribution_title': 'Status Distribution (Semester)',
+        'status_distribution_subtitle': 'How are applications distributed between pending, accepted, and rejected this semester?',
+        'per_offer_breakdown': 'Per-offer breakdown',
+        'no_status_data': 'No application data available for this semester',
+        'status_offline_banner': 'No connection — showing saved data',
         // ── Form fields & hints ──
         'offer_details': 'Offer Details',
         'offer_subtitle': 'Fill in the fields to publish your new request.',

--- a/flutter_application_goatly/lib/features/staff/analytics/analytics_shell.dart
+++ b/flutter_application_goatly/lib/features/staff/analytics/analytics_shell.dart
@@ -11,6 +11,7 @@ import 'applications_per_semester_page.dart';
 import 'gpa_dashboard_page.dart';
 import 'gpa_high_rate_page.dart';
 import 'insights_page.dart';
+import 'status_distribution_page.dart';
 import 'top_applicants_page.dart';
 
 class AnalyticsShell extends StatefulWidget {
@@ -27,7 +28,7 @@ class _AnalyticsShellState extends State<AnalyticsShell>
   @override
   void initState() {
     super.initState();
-    _controller = TabController(length: 6, vsync: this);
+    _controller = TabController(length: 7, vsync: this);
     _controller.addListener(_handleTabChange);
     // Multi-threading: Future.wait lanza ambas peticiones HTTP simultáneamente
     // sin bloquear el UI thread, reduciendo el tiempo total de carga.
@@ -41,7 +42,8 @@ class _AnalyticsShellState extends State<AnalyticsShell>
         ApiService.getGpaByOffer(),
         ApiService.getTopApplicants(),
         ApiService.getApplicationsPerSemester(),
-        ApiService.getGpaHighRate(), // BQ9 — warm LRU cache alongside team's BQs
+        ApiService.getGpaHighRate(),          // BQ9 — warm LRU cache alongside team's BQs
+        ApiService.getStatusDistribution(),   // BQ13 — pre-warm cache on shell load
       ]);
     } catch (_) {
       // Errors handled individually by each page's own cache-first logic.
@@ -92,6 +94,10 @@ class _AnalyticsShellState extends State<AnalyticsShell>
       _AnalyticsTabMeta(
         label: context.t('apps_per_semester'),
         icon: Icons.bar_chart_rounded,
+      ),
+      _AnalyticsTabMeta(
+        label: context.t('status_distribution'),
+        icon: Icons.donut_large_outlined,
       ),
     ];
 
@@ -166,6 +172,7 @@ class _AnalyticsShellState extends State<AnalyticsShell>
                 TopApplicantsPage(),
                 GpaHighRatePage(),
                 ApplicationsPerSemesterPage(),
+                StatusDistributionPage(),
               ],
             ),
           ),

--- a/flutter_application_goatly/lib/features/staff/analytics/status_distribution_page.dart
+++ b/flutter_application_goatly/lib/features/staff/analytics/status_distribution_page.dart
@@ -1,0 +1,566 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/foundation.dart'; // compute()
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../../app/localization.dart';
+import '../../../app/theme.dart';
+import '../../../data/settings_state.dart';
+import '../../../services/api_service.dart';
+import '../../../services/cache_service.dart';
+import '../../../services/connectivity_service.dart';
+
+// ── Top-level function so compute() can send it to a background isolate ──────
+// Sorts per_offer list by total (descending) — keeps heavy work off the UI thread.
+Map<String, dynamic> _processPayload(Map<String, dynamic> raw) {
+  final perOffer = List<Map<String, dynamic>>.from(
+    (raw['per_offer'] as List<dynamic>).cast<Map<String, dynamic>>(),
+  );
+  perOffer.sort((a, b) {
+    final tA = (a['total'] as num?)?.toInt() ?? 0;
+    final tB = (b['total'] as num?)?.toInt() ?? 0;
+    return tB.compareTo(tA);
+  });
+  return {
+    'semester': raw['semester'],
+    'total_applications': raw['total_applications'],
+    'distribution': raw['distribution'],
+    'per_offer': perOffer,
+  };
+}
+
+// ── Page ──────────────────────────────────────────────────────────────────────
+
+class StatusDistributionPage extends StatefulWidget {
+  const StatusDistributionPage({super.key});
+
+  @override
+  State<StatusDistributionPage> createState() => _StatusDistributionPageState();
+}
+
+class _StatusDistributionPageState extends State<StatusDistributionPage> {
+  static const _cacheKey = 'status_distribution';
+  late Future<Map<String, dynamic>> _future;
+  bool _servedFromCache = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = _load();
+  }
+
+  /// Stale-while-revalidate + Isolate (compute):
+  /// 1. Load from LRU/disk cache immediately — fast, offline-safe.
+  /// 2. If offline and cache exists → return cache; otherwise throw NetworkException.
+  /// 3. If online → fetch fresh data, sort in a background isolate, persist to cache.
+  Future<Map<String, dynamic>> _load() async {
+    final cached = await CacheService.loadAnalytics(_cacheKey);
+
+    if (!ConnectivityService.isOnline) {
+      if (cached != null) {
+        _servedFromCache = true;
+        return Map<String, dynamic>.from(cached);
+      }
+      throw const NetworkException();
+    }
+
+    try {
+      final fresh = await ApiService.getStatusDistribution();
+      // compute() runs _processPayload in a background isolate — no UI jank.
+      final processed = await compute(_processPayload, fresh);
+      await CacheService.saveAnalytics(_cacheKey, processed);
+      _servedFromCache = false;
+      return processed;
+    } catch (_) {
+      if (cached != null) {
+        _servedFromCache = true;
+        return Map<String, dynamic>.from(cached);
+      }
+      rethrow;
+    }
+  }
+
+  void _reload() {
+    setState(() {
+      _servedFromCache = false;
+      _future = _load();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    context.watch<SettingsState>();
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+
+    return FutureBuilder<Map<String, dynamic>>(
+      future: _future,
+      builder: (context, snapshot) {
+        // ── Loading ──────────────────────────────────────────────────────────
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const CircularProgressIndicator(color: AppColors.primaryYellow),
+                const SizedBox(height: 12),
+                Text(context.t('loading')),
+              ],
+            ),
+          );
+        }
+
+        // ── Error ────────────────────────────────────────────────────────────
+        if (snapshot.hasError) {
+          final isNetwork =
+              snapshot.error is NetworkException || !ConnectivityService.isOnline;
+          return Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(
+                  isNetwork ? Icons.wifi_off_rounded : Icons.error_outline,
+                  size: 48,
+                  color: isDark ? AppColors.darkGreyText : AppColors.greyText,
+                ),
+                const SizedBox(height: 12),
+                Text(
+                  isNetwork
+                      ? context.t('no_cache_offline')
+                      : context.t('error_loading'),
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 12),
+                ElevatedButton.icon(
+                  onPressed: _reload,
+                  icon: const Icon(Icons.refresh),
+                  label: Text(context.t('retry')),
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: AppColors.primaryYellow,
+                    foregroundColor: Colors.black,
+                  ),
+                ),
+              ],
+            ),
+          );
+        }
+
+        final data = snapshot.data!;
+        final distribution =
+            (data['distribution'] as List<dynamic>).cast<Map<String, dynamic>>();
+        final perOffer =
+            (data['per_offer'] as List<dynamic>).cast<Map<String, dynamic>>();
+        final semester = data['semester'] as String? ?? '';
+        final totalApps = (data['total_applications'] as num?)?.toInt() ?? 0;
+
+        // ── Empty ────────────────────────────────────────────────────────────
+        if (totalApps == 0) {
+          return Center(
+            child: Text(
+              context.t('no_status_data'),
+              style: TextStyle(
+                color: isDark ? AppColors.darkGreyText : AppColors.greyText,
+                fontSize: 16,
+              ),
+            ),
+          );
+        }
+
+        // ── Main content ─────────────────────────────────────────────────────
+        return RefreshIndicator(
+          onRefresh: () async => _reload(),
+          color: AppColors.primaryYellow,
+          child: ListView(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 32),
+            children: [
+              // Offline banner
+              if (_servedFromCache && !ConnectivityService.isOnline)
+                _OfflineBanner(message: context.t('status_offline_banner')),
+
+              // Last updated label
+              _LastUpdatedLabel(cacheKey: _cacheKey, isDark: isDark, prefix: context.t('last_updated')),
+
+              // Title + semester chip
+              Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      context.t('status_distribution_title'),
+                      style: const TextStyle(
+                        fontSize: 20,
+                        fontWeight: FontWeight.w900,
+                      ),
+                    ),
+                  ),
+                  Container(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+                    decoration: BoxDecoration(
+                      color: AppColors.primaryYellow.withValues(alpha: 0.15),
+                      borderRadius: BorderRadius.circular(20),
+                      border: Border.all(
+                          color: AppColors.primaryYellow.withValues(alpha: 0.4)),
+                    ),
+                    child: Text(
+                      semester,
+                      style: const TextStyle(
+                        fontSize: 13,
+                        fontWeight: FontWeight.w800,
+                        color: AppColors.primaryYellow,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 4),
+              Text(
+                context.t('status_distribution_subtitle'),
+                style: TextStyle(
+                  fontSize: 13,
+                  color: isDark ? AppColors.darkGreyText : AppColors.greyText,
+                  height: 1.35,
+                ),
+              ),
+
+              const SizedBox(height: 24),
+
+              // Donut chart
+              _DonutSection(
+                distribution: distribution,
+                totalApps: totalApps,
+                isDark: isDark,
+              ),
+
+              const SizedBox(height: 28),
+
+              // Per-offer breakdown header
+              Text(
+                context.t('per_offer_breakdown'),
+                style: const TextStyle(
+                  fontSize: 17,
+                  fontWeight: FontWeight.w900,
+                ),
+              ),
+              const SizedBox(height: 12),
+
+              // Offer cards
+              ...perOffer.map(
+                (row) => _OfferBreakdownCard(row: row, isDark: isDark),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+// ── Donut chart section ───────────────────────────────────────────────────────
+
+class _DonutSection extends StatelessWidget {
+  final List<Map<String, dynamic>> distribution;
+  final int totalApps;
+  final bool isDark;
+
+  const _DonutSection({
+    required this.distribution,
+    required this.totalApps,
+    required this.isDark,
+  });
+
+  Color _colorFor(String status) => switch (status) {
+        'accepted' => AppColors.success,
+        'rejected' => AppColors.danger,
+        _ => const Color(0xFFF5A623), // pending — amber/yellow
+      };
+
+  String _labelKey(String status, BuildContext context) => switch (status) {
+        'accepted' => context.t('accepted_label'),
+        'rejected' => context.t('rejected_label'),
+        _ => context.t('pending_label'),
+      };
+
+  @override
+  Widget build(BuildContext context) {
+    final sections = distribution
+        .where((d) => ((d['count'] as num?)?.toInt() ?? 0) > 0)
+        .map((d) {
+      final status = d['status'] as String;
+      final pct = (d['percentage'] as num?)?.toDouble() ?? 0.0;
+      return PieChartSectionData(
+        value: pct,
+        color: _colorFor(status),
+        radius: 54,
+        showTitle: false,
+      );
+    }).toList();
+
+    // Fallback: if all zeros, show a single grey slice
+    final chartSections = sections.isEmpty
+        ? [PieChartSectionData(value: 1, color: AppColors.border, radius: 54, showTitle: false)]
+        : sections;
+
+    return Column(
+      children: [
+        SizedBox(
+          height: 220,
+          child: Stack(
+            alignment: Alignment.center,
+            children: [
+              PieChart(
+                PieChartData(
+                  sections: chartSections,
+                  centerSpaceRadius: 66,
+                  sectionsSpace: 3,
+                  startDegreeOffset: -90,
+                ),
+              ),
+              Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    '$totalApps',
+                    style: const TextStyle(
+                      fontSize: 28,
+                      fontWeight: FontWeight.w900,
+                    ),
+                  ),
+                  Text(
+                    context.t('total_applications'),
+                    style: TextStyle(
+                      fontSize: 11,
+                      color: isDark ? AppColors.darkGreyText : AppColors.greyText,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 16),
+        // Legend
+        Wrap(
+          spacing: 16,
+          runSpacing: 8,
+          alignment: WrapAlignment.center,
+          children: distribution.map((d) {
+            final status = d['status'] as String;
+            final count = (d['count'] as num?)?.toInt() ?? 0;
+            final pct = (d['percentage'] as num?)?.toDouble() ?? 0.0;
+            final color = _colorFor(status);
+            return Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Container(
+                  width: 12,
+                  height: 12,
+                  decoration: BoxDecoration(
+                    color: color,
+                    shape: BoxShape.circle,
+                  ),
+                ),
+                const SizedBox(width: 6),
+                Text(
+                  '${_labelKey(status, context)}: $count (${pct.toStringAsFixed(1)}%)',
+                  style: TextStyle(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w700,
+                    color: isDark ? AppColors.darkModeText : AppColors.darkText,
+                  ),
+                ),
+              ],
+            );
+          }).toList(),
+        ),
+      ],
+    );
+  }
+}
+
+// ── Per-offer breakdown card ───────────────────────────────────────────────────
+
+class _OfferBreakdownCard extends StatelessWidget {
+  final Map<String, dynamic> row;
+  final bool isDark;
+
+  const _OfferBreakdownCard({required this.row, required this.isDark});
+
+  @override
+  Widget build(BuildContext context) {
+    final title = row['offer_title'] as String? ?? '';
+    final category = row['category'] as String? ?? '';
+    final pending = (row['pending'] as num?)?.toInt() ?? 0;
+    final accepted = (row['accepted'] as num?)?.toInt() ?? 0;
+    final rejected = (row['rejected'] as num?)?.toInt() ?? 0;
+    final total = (row['total'] as num?)?.toInt() ?? 0;
+
+    final surfaceColor = isDark ? AppColors.darkSurface : AppColors.surface;
+    final borderColor = isDark ? AppColors.darkBorder : AppColors.border;
+    final greyText = isDark ? AppColors.darkGreyText : AppColors.greyText;
+
+    return Container(
+      margin: const EdgeInsets.only(bottom: 12),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: surfaceColor,
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: borderColor),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w900),
+          ),
+          if (category.isNotEmpty) ...[
+            const SizedBox(height: 3),
+            Text(category,
+                style: TextStyle(color: greyText, fontSize: 13)),
+          ],
+          const SizedBox(height: 12),
+          Wrap(
+            spacing: 8,
+            runSpacing: 6,
+            children: [
+              _StatusChip(
+                label: context.t('pending_label'),
+                count: pending,
+                color: const Color(0xFFF5A623),
+              ),
+              _StatusChip(
+                label: context.t('accepted_label'),
+                count: accepted,
+                color: AppColors.success,
+              ),
+              _StatusChip(
+                label: context.t('rejected_label'),
+                count: rejected,
+                color: AppColors.danger,
+              ),
+              _StatusChip(
+                label: context.t('total_applications'),
+                count: total,
+                color: greyText,
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StatusChip extends StatelessWidget {
+  final String label;
+  final int count;
+  final Color color;
+
+  const _StatusChip({
+    required this.label,
+    required this.count,
+    required this.color,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            label,
+            style: TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+              color: color,
+            ),
+          ),
+          const SizedBox(width: 6),
+          Text(
+            '$count',
+            style: TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w900,
+              color: color,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+class _OfflineBanner extends StatelessWidget {
+  final String message;
+  const _OfflineBanner({required this.message});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      margin: const EdgeInsets.only(bottom: 12),
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+      decoration: BoxDecoration(
+        color: Colors.orange.withValues(alpha: 0.15),
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: Colors.orange.withValues(alpha: 0.4)),
+      ),
+      child: Row(
+        children: [
+          const Icon(Icons.cloud_off_rounded, size: 16, color: Colors.orange),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              message,
+              style: const TextStyle(
+                color: Colors.orange,
+                fontSize: 13,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _LastUpdatedLabel extends StatelessWidget {
+  final String cacheKey;
+  final bool isDark;
+  final String prefix;
+
+  const _LastUpdatedLabel({
+    required this.cacheKey,
+    required this.isDark,
+    required this.prefix,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<String?>(
+      future: CacheService.getAnalyticsTimestamp(cacheKey),
+      builder: (context, snap) {
+        if (!snap.hasData || snap.data == null) return const SizedBox.shrink();
+        return Padding(
+          padding: const EdgeInsets.only(bottom: 10),
+          child: Text(
+            '$prefix: ${snap.data}',
+            style: TextStyle(
+              fontSize: 12,
+              color: isDark ? AppColors.darkGreyText : AppColors.greyText,
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/flutter_application_goatly/lib/features/staff/home/applicant_list_page.dart
+++ b/flutter_application_goatly/lib/features/staff/home/applicant_list_page.dart
@@ -184,6 +184,7 @@ class _ApplicantListPageState extends State<ApplicantListPage> {
                         offer: widget.offer,
                         surface: surface,
                         border: border,
+                        onRefresh: _loadApplicants,
                       ),
           ),
         ],
@@ -550,12 +551,14 @@ class _ApplicantList extends StatelessWidget {
   final OfferModel offer;
   final Color surface;
   final Color border;
+  final VoidCallback onRefresh;
 
   const _ApplicantList({
     required this.applicants,
     required this.offer,
     required this.surface,
     required this.border,
+    required this.onRefresh,
   });
 
   @override
@@ -571,12 +574,15 @@ class _ApplicantList extends StatelessWidget {
           rank: i + 1,
           surface: surface,
           border: border,
-          onTap: () => Navigator.push(
-            context,
-            MaterialPageRoute(
-              builder: (_) => ApplicationDetailPage(app: app),
-            ),
-          ),
+          onTap: () async {
+            await Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (_) => ApplicationDetailPage(app: app),
+              ),
+            );
+            onRefresh();
+          },
         );
       },
     );

--- a/flutter_application_goatly/lib/services/api_service.dart
+++ b/flutter_application_goatly/lib/services/api_service.dart
@@ -481,6 +481,25 @@ class ApiService {
     return list.cast<Map<String, dynamic>>();
   }
 
+  // ── BQ13 (David Hernandez) ─ Status Distribution per Semester ────────────
+
+  /// GET /analytics/status-distribution[?semester=YYYY-N]
+  /// BQ13: Distribution of pending/accepted/rejected applications this semester.
+  /// Returns a Map with keys: semester, total_applications, distribution, per_offer.
+  static Future<Map<String, dynamic>> getStatusDistribution({String? semester}) async {
+    final uri = semester != null
+        ? Uri.parse('$baseUrl/analytics/status-distribution?semester=$semester')
+        : Uri.parse('$baseUrl/analytics/status-distribution');
+
+    final res = await http.get(uri, headers: _headers).timeout(const Duration(seconds: 10));
+
+    if (res.statusCode != 200) {
+      throw ApiException(
+          'Error al obtener distribución de estados (${res.statusCode})');
+    }
+    return jsonDecode(res.body) as Map<String, dynamic>;
+  }
+
   // ── BQ7 (Santiago Reyes) ─ Time to First Application ──────────────────
 
   /// GET /analytics/time-to-first-application

--- a/flutter_application_goatly/pubspec.lock
+++ b/flutter_application_goatly/pubspec.lock
@@ -105,6 +105,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.12"
+  equatable:
+    dependency: transitive
+    description:
+      name: equatable
+      sha256: "3e0141505477fd8ad55d6eb4e7776d3fe8430be8e497ccb1521370c3f21a3e2b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.8"
   fake_async:
     dependency: transitive
     description:
@@ -161,6 +169,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.9.3+5"
+  fl_chart:
+    dependency: "direct main"
+    description:
+      name: fl_chart
+      sha256: b938f77d042cbcd822936a7a359a7235bad8bd72070de1f827efc2cc297ac888
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.0"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/flutter_application_goatly/pubspec.yaml
+++ b/flutter_application_goatly/pubspec.yaml
@@ -49,6 +49,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  fl_chart: ^1.2.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- Fix accept/reject bug: await Navigator.push in ApplicantListPage so the applicant list refreshes after returning from ApplicationDetailPage
- Add fl_chart dependency for donut chart rendering
- Add ApiService.getStatusDistribution() — GET /analytics/status-distribution
- Add 6 new localization keys (es + en) for BQ13 screen
- Add StatusDistributionPage: cache-first offline architecture, compute() isolate for per-offer sorting, donut chart (PieChart), legend with counts/percentages, per-offer breakdown cards, offline banner, last-updated label, RefreshIndicator
- Integrate 7th tab in AnalyticsShell with parallel prefetch (Future.wait)

Closes #39