### PR TITLE
Add BQ11 offer lifecycle screen and micro-optimizations

### DIFF
--- a/flutter_application_goatly/lib/data/settings_state.dart
+++ b/flutter_application_goatly/lib/data/settings_state.dart
@@ -467,6 +467,14 @@ class SettingsState extends ChangeNotifier with WidgetsBindingObserver {
         'stat_total_rated': 'Calificados',
         'stat_avg_rating': 'Prom. Rating',
         'average': 'Promedio',
+        // ── BQ11 (Santiago Reyes) ─ Offer Lifecycle ──
+        'offer_lifecycle': 'Ciclo de Oferta',
+        'offer_lifecycle_title': 'Ciclo de vida de ofertas',
+        'offer_lifecycle_subtitle': 'Tiempo promedio que una oferta permanece abierta desde su publicación hasta su cierre',
+        'offer_lifecycle_avg_label': 'días promedio abierta',
+        'offer_lifecycle_min': 'Mín. días',
+        'offer_lifecycle_max': 'Máx. días',
+        'offer_lifecycle_total': 'Ofertas cerradas',
       },
       'en': {
         'settings': 'Settings',
@@ -829,6 +837,14 @@ class SettingsState extends ChangeNotifier with WidgetsBindingObserver {
         'stat_total_rated': 'Rated',
         'stat_avg_rating': 'Avg. Rating',
         'average': 'Average',
+        // ── BQ11 (Santiago Reyes) ─ Offer Lifecycle ──
+        'offer_lifecycle': 'Offer Lifecycle',
+        'offer_lifecycle_title': 'Offer lifecycle',
+        'offer_lifecycle_subtitle': 'Average time an offer stays open from publication until it is closed',
+        'offer_lifecycle_avg_label': 'avg days open',
+        'offer_lifecycle_min': 'Min days',
+        'offer_lifecycle_max': 'Max days',
+        'offer_lifecycle_total': 'Closed offers',
       }
     };
 

--- a/flutter_application_goatly/lib/features/staff/analytics/analytics_shell.dart
+++ b/flutter_application_goatly/lib/features/staff/analytics/analytics_shell.dart
@@ -11,6 +11,7 @@ import 'applications_per_semester_page.dart';
 import 'gpa_dashboard_page.dart';
 import 'gpa_high_rate_page.dart';
 import 'insights_page.dart';
+import 'offer_lifecycle_screen.dart';
 import 'top_applicants_page.dart';
 
 class AnalyticsShell extends StatefulWidget {
@@ -27,7 +28,7 @@ class _AnalyticsShellState extends State<AnalyticsShell>
   @override
   void initState() {
     super.initState();
-    _controller = TabController(length: 6, vsync: this);
+    _controller = TabController(length: 7, vsync: this);
     _controller.addListener(_handleTabChange);
     // Multi-threading: Future.wait lanza ambas peticiones HTTP simultáneamente
     // sin bloquear el UI thread, reduciendo el tiempo total de carga.
@@ -37,11 +38,14 @@ class _AnalyticsShellState extends State<AnalyticsShell>
   Future<void> _prefetchGuillermosData() async {
     if (!ConnectivityService.isOnline) return;
     try {
+      // Multi-threading: Future.wait launches all requests simultaneously on
+      // Dart's event loop without blocking the UI thread.
       await Future.wait([
         ApiService.getGpaByOffer(),
         ApiService.getTopApplicants(),
         ApiService.getApplicationsPerSemester(),
-        ApiService.getGpaHighRate(), // BQ9 — warm LRU cache alongside team's BQs
+        ApiService.getGpaHighRate(),      // BQ9
+        ApiService.getOfferLifecycle(),   // BQ11 — warm LRU cache in parallel
       ]);
     } catch (_) {
       // Errors handled individually by each page's own cache-first logic.
@@ -92,6 +96,10 @@ class _AnalyticsShellState extends State<AnalyticsShell>
       _AnalyticsTabMeta(
         label: context.t('apps_per_semester'),
         icon: Icons.bar_chart_rounded,
+      ),
+      _AnalyticsTabMeta(
+        label: context.t('offer_lifecycle'),
+        icon: Icons.timeline_rounded,
       ),
     ];
 
@@ -166,6 +174,7 @@ class _AnalyticsShellState extends State<AnalyticsShell>
                 TopApplicantsPage(),
                 GpaHighRatePage(),
                 ApplicationsPerSemesterPage(),
+                OfferLifecycleScreen(),
               ],
             ),
           ),

--- a/flutter_application_goatly/lib/features/staff/analytics/offer_lifecycle_screen.dart
+++ b/flutter_application_goatly/lib/features/staff/analytics/offer_lifecycle_screen.dart
@@ -1,0 +1,439 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../../app/localization.dart';
+import '../../../app/theme.dart';
+import '../../../data/app_state.dart';
+import '../../../data/settings_state.dart';
+import '../../../services/api_service.dart';
+import '../../../services/cache_service.dart';
+import '../../../services/hive_cache_service.dart';
+
+// ── Isolate helpers ───────────────────────────────────────────────────────────
+
+/// Data model produced by the isolate computation.
+class _LifecycleStats {
+  final double averageDays;
+  final int minDays;
+  final int maxDays;
+  final int totalOffers;
+
+  const _LifecycleStats({
+    required this.averageDays,
+    required this.minDays,
+    required this.maxDays,
+    required this.totalOffers,
+  });
+}
+
+/// Top-level function required by compute() — runs in a separate Dart isolate.
+/// Parses and validates the raw JSON map returned by the backend so the main
+/// UI thread is never blocked by JSON decoding or type-casting.
+_LifecycleStats _computeLifecycleStats(Map<String, dynamic> raw) {
+  final averageDays = (raw['average_days'] as num?)?.toDouble() ?? 0.0;
+  final minDays = (raw['min_days'] as num?)?.toInt() ?? 0;
+  final maxDays = (raw['max_days'] as num?)?.toInt() ?? 0;
+  final totalOffers = (raw['total_offers'] as num?)?.toInt() ?? 0;
+  return _LifecycleStats(
+    averageDays: averageDays,
+    minDays: minDays,
+    maxDays: maxDays,
+    totalOffers: totalOffers,
+  );
+}
+
+// ── Screen ────────────────────────────────────────────────────────────────────
+
+/// BQ11 (Santiago Reyes): Offer Lifecycle Analytics Screen.
+///
+/// Displays: average, min, max days an offer stays open + total closed offers.
+///
+/// Cache strategy (LRU → Hive → SharedPreferences):
+///   1. Tier 1 (LRU, in-memory) — served instantly, no I/O.
+///   2. Tier 2 (Hive, fast disk) — survives hot-restart.
+///   3. Tier 3 (SharedPreferences) — survives cold-start.
+///   SharedPreferences key: cached_analytics_bq11_offer_lifecycle
+///
+/// Offline: renders last cached data with a "Last updated: [timestamp]" banner.
+class OfferLifecycleScreen extends StatefulWidget {
+  const OfferLifecycleScreen({super.key});
+
+  @override
+  State<OfferLifecycleScreen> createState() => _OfferLifecycleScreenState();
+}
+
+class _OfferLifecycleScreenState extends State<OfferLifecycleScreen> {
+  _LifecycleStats? _stats;
+  String? _lastUpdated;
+  bool _loading = false;
+  String? _error;
+
+  // Cache key used by all three tiers.
+  static const _cacheKey = 'bq11_offer_lifecycle';
+
+  @override
+  void initState() {
+    super.initState();
+    _loadWithCache();
+  }
+
+  // ── Cache-first load ──────────────────────────────────────────────────────
+
+  Future<void> _loadWithCache() async {
+    // Tier 2: Hive (synchronous after init — no await needed for reads).
+    final hiveData = HiveCacheService.loadAnalytics(_cacheKey);
+    final hiveTs = HiveCacheService.getTimestamp(_cacheKey);
+    if (hiveData != null) {
+      final s = await compute(_computeLifecycleStats, hiveData);
+      if (mounted) setState(() { _stats = s; _lastUpdated = hiveTs; });
+    } else {
+      // Tier 3: SharedPreferences (LRU is checked internally first).
+      final cached = await CacheService.loadAnalytics(_cacheKey);
+      final ts = await CacheService.getAnalyticsTimestamp(_cacheKey);
+      if (cached != null) {
+        final s = await compute(_computeLifecycleStats, cached);
+        if (mounted) setState(() { _stats = s; _lastUpdated = ts; });
+      } else {
+        if (mounted) setState(() => _loading = true);
+      }
+    }
+    await _refreshFromNetwork();
+  }
+
+  Future<void> _refreshFromNetwork() async {
+    if (mounted) setState(() { _loading = true; _error = null; });
+    try {
+      final raw = await ApiService.getOfferLifecycle();
+      // compute() runs _computeLifecycleStats in a background isolate so the
+      // main thread is not blocked by JSON parsing or arithmetic.
+      final s = await compute(_computeLifecycleStats, raw);
+      await HiveCacheService.saveAnalytics(_cacheKey, raw);
+      await CacheService.saveAnalytics(_cacheKey, raw);
+      final ts = await CacheService.getAnalyticsTimestamp(_cacheKey);
+      if (mounted) {
+        setState(() { _stats = s; _lastUpdated = ts; _loading = false; });
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _loading = false;
+          if (_stats == null) _error = 'Sin conexión y sin datos en caché.';
+        });
+      }
+    }
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────────────────
+
+  String _fmtTimestamp(String? iso) {
+    if (iso == null) return '';
+    final dt = DateTime.tryParse(iso);
+    if (dt == null) return '';
+    final local = dt.toLocal();
+    final dd = local.day.toString().padLeft(2, '0');
+    final mm = local.month.toString().padLeft(2, '0');
+    final hh = local.hour.toString().padLeft(2, '0');
+    final min = local.minute.toString().padLeft(2, '0');
+    return '$dd/$mm $hh:$min';
+  }
+
+  // ── Build ─────────────────────────────────────────────────────────────────
+
+  @override
+  Widget build(BuildContext context) {
+    context.watch<SettingsState>();
+    final isOnline = context.watch<AppState>().isOnline;
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+
+    if (_error != null && _stats == null) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.wifi_off_rounded,
+                size: 48,
+                color: isDark ? AppColors.darkGreyText : AppColors.greyText),
+            const SizedBox(height: 12),
+            Text(context.t('no_cache_offline')),
+            const SizedBox(height: 12),
+            ElevatedButton.icon(
+              onPressed: _loadWithCache,
+              icon: const Icon(Icons.refresh),
+              label: Text(context.t('retry')),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: AppColors.primaryYellow,
+                foregroundColor: Colors.black,
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    if (_stats == null && _loading) {
+      return const Center(
+        child: CircularProgressIndicator(color: AppColors.primaryYellow),
+      );
+    }
+
+    final stats = _stats;
+
+    return Column(
+      children: [
+        // Offline banner
+        if (!isOnline)
+          Container(
+            width: double.infinity,
+            color: Colors.orange.shade700,
+            padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 16),
+            child: const Row(
+              children: [
+                Icon(Icons.wifi_off, color: Colors.white, size: 16),
+                SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    'Sin conexión — mostrando datos en caché',
+                    style: TextStyle(color: Colors.white, fontSize: 13),
+                  ),
+                ),
+              ],
+            ),
+          ),
+
+        Expanded(
+          child: RefreshIndicator(
+            onRefresh: _refreshFromNetwork,
+            color: AppColors.primaryYellow,
+            child: ListView(
+              padding: const EdgeInsets.fromLTRB(16, 20, 16, 32),
+              children: [
+                _BQ11Header(
+                  isDark: isDark,
+                  lastUpdated: _fmtTimestamp(_lastUpdated),
+                  loading: _loading,
+                  context: context,
+                ),
+                if (stats != null)
+                  _BQ11Card(stats: stats, isDark: isDark),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// ── Header ────────────────────────────────────────────────────────────────────
+
+class _BQ11Header extends StatelessWidget {
+  final bool isDark;
+  final String lastUpdated;
+  final bool loading;
+  final BuildContext context;
+
+  const _BQ11Header({
+    required this.isDark,
+    required this.lastUpdated,
+    required this.loading,
+    required this.context,
+  });
+
+  @override
+  Widget build(BuildContext ctx) {
+    final mutedText = isDark ? AppColors.darkGreyText : AppColors.greyText;
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            context.t('offer_lifecycle_title'),
+            style: const TextStyle(fontSize: 22, fontWeight: FontWeight.w900),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            context.t('offer_lifecycle_subtitle'),
+            style: TextStyle(color: mutedText, fontSize: 13, height: 1.4),
+          ),
+          if (lastUpdated.isNotEmpty) ...[
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                const Icon(Icons.update_rounded, size: 13, color: AppColors.greyText),
+                const SizedBox(width: 5),
+                Text(
+                  '${context.t('last_updated')}: $lastUpdated',
+                  style: const TextStyle(color: AppColors.greyText, fontSize: 12),
+                ),
+                if (loading) ...[
+                  const SizedBox(width: 8),
+                  const SizedBox(
+                    width: 12,
+                    height: 12,
+                    child: CircularProgressIndicator(
+                        strokeWidth: 1.5, color: AppColors.primaryYellow),
+                  ),
+                ],
+              ],
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+// ── Stats card ────────────────────────────────────────────────────────────────
+
+class _BQ11Card extends StatelessWidget {
+  final _LifecycleStats stats;
+  final bool isDark;
+
+  const _BQ11Card({required this.stats, required this.isDark});
+
+  @override
+  Widget build(BuildContext context) {
+    final surfaceColor = isDark ? AppColors.darkSurface : AppColors.surface;
+    final borderColor = isDark ? AppColors.darkBorder : AppColors.border;
+
+    return Container(
+      padding: const EdgeInsets.fromLTRB(20, 18, 20, 20),
+      decoration: BoxDecoration(
+        color: surfaceColor,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: borderColor),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // BQ label
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+            decoration: BoxDecoration(
+              color: AppColors.primaryYellow.withValues(alpha: 0.15),
+              borderRadius: BorderRadius.circular(6),
+            ),
+            child: const Text(
+              'BQ11',
+              style: TextStyle(
+                color: Color(0xFF9A5B00),
+                fontWeight: FontWeight.w900,
+                fontSize: 12,
+              ),
+            ),
+          ),
+          const SizedBox(height: 12),
+
+          // Title
+          Text(
+            context.t('offer_lifecycle_title'),
+            style: const TextStyle(
+                fontSize: 19, fontWeight: FontWeight.w800, height: 1.3),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            context.t('offer_lifecycle_subtitle'),
+            style: const TextStyle(
+                color: AppColors.greyText, fontSize: 14, height: 1.4),
+          ),
+          const SizedBox(height: 24),
+
+          // Main metric — average days
+          Center(
+            child: Column(
+              children: [
+                Text(
+                  stats.averageDays.toStringAsFixed(1),
+                  style: const TextStyle(
+                    fontSize: 64,
+                    fontWeight: FontWeight.w900,
+                    color: AppColors.primaryYellow,
+                    height: 1,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  context.t('offer_lifecycle_avg_label'),
+                  style: const TextStyle(
+                      fontSize: 16, color: AppColors.greyText),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 28),
+
+          // Sub-metrics row
+          Row(
+            children: [
+              Expanded(
+                child: _SubMetric(
+                  value: stats.minDays.toString(),
+                  label: context.t('offer_lifecycle_min'),
+                  color: AppColors.success,
+                  borderColor: borderColor,
+                ),
+              ),
+              Container(width: 1, height: 48, color: borderColor),
+              Expanded(
+                child: _SubMetric(
+                  value: stats.maxDays.toString(),
+                  label: context.t('offer_lifecycle_max'),
+                  color: AppColors.danger,
+                  borderColor: borderColor,
+                ),
+              ),
+              Container(width: 1, height: 48, color: borderColor),
+              Expanded(
+                child: _SubMetric(
+                  value: stats.totalOffers.toString(),
+                  label: context.t('offer_lifecycle_total'),
+                  color: AppColors.primaryYellow,
+                  borderColor: borderColor,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SubMetric extends StatelessWidget {
+  final String value;
+  final String label;
+  final Color color;
+  final Color borderColor;
+
+  const _SubMetric({
+    required this.value,
+    required this.label,
+    required this.color,
+    required this.borderColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 10),
+      child: Column(
+        children: [
+          Text(
+            value,
+            style: TextStyle(
+                fontSize: 26, fontWeight: FontWeight.w900, color: color),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            label,
+            textAlign: TextAlign.center,
+            style: const TextStyle(
+                color: AppColors.greyText, fontSize: 12, height: 1.3),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/flutter_application_goatly/lib/features/staff/create/offer_card.dart
+++ b/flutter_application_goatly/lib/features/staff/create/offer_card.dart
@@ -1,0 +1,263 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../../app/localization.dart';
+import '../../../app/theme.dart';
+import '../../../data/app_state.dart';
+import '../../../models/offer_model.dart';
+import '../../../services/api_service.dart';
+import 'edit_offer_page.dart';
+
+/// Public offer card widget for the staff offers list.
+///
+/// Memory optimisations applied:
+///   • Wrapped in RepaintBoundary — Flutter skips repainting this subtree
+///     when neighbouring list items scroll into/out of view.
+///   • CachedNetworkImage uses memCacheWidth/Height: 160 px, so only a
+///     downscaled bitmap is kept in the image cache (not the full resolution).
+///   • maxWidthDiskCache / maxHeightDiskCache: 160 px caps what is written
+///     to the on-disk LRU managed by cached_network_image.
+class OfferCard extends StatelessWidget {
+  final OfferModel offer;
+  final bool isDark;
+
+  const OfferCard({
+    super.key,
+    required this.offer,
+    required this.isDark,
+  });
+
+  String _fmtDateTime(DateTime d) {
+    final mm = d.month.toString().padLeft(2, '0');
+    final dd = d.day.toString().padLeft(2, '0');
+    final hh = (d.hour % 12 == 0 ? 12 : d.hour % 12).toString();
+    final min = d.minute.toString().padLeft(2, '0');
+    final ampm = d.hour < 12 ? 'AM' : 'PM';
+    return '$mm/$dd ${hh.padLeft(2, '0')}:$min $ampm';
+  }
+
+  Future<void> _deleteOffer(BuildContext context) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+        title: Text(context.t('delete_offer_confirm'),
+            style: const TextStyle(fontWeight: FontWeight.w800)),
+        content: Text(context.t('delete_offer_body')),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: Text(context.t('cancel'),
+                style: const TextStyle(color: AppColors.greyText)),
+          ),
+          ElevatedButton(
+            style: ElevatedButton.styleFrom(
+              backgroundColor: AppColors.danger,
+              foregroundColor: Colors.white,
+              shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(10)),
+            ),
+            onPressed: () => Navigator.pop(ctx, true),
+            child: Text(context.t('delete'),
+                style: const TextStyle(fontWeight: FontWeight.w700)),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true || !context.mounted) return;
+
+    try {
+      await ApiService.deleteOffer(offer.id);
+      if (context.mounted) {
+        context.read<AppState>().removeOffer(offer.id);
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(context.t('offer_deleted')),
+            backgroundColor: AppColors.success,
+            behavior: SnackBarBehavior.floating,
+          ),
+        );
+      }
+    } catch (e) {
+      if (context.mounted) {
+        final msg = e is ApiException
+            ? e.message
+            : 'Sin conexión — no se pudo eliminar la oferta';
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(msg),
+            backgroundColor: AppColors.danger,
+            behavior: SnackBarBehavior.floating,
+          ),
+        );
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final surfaceColor = isDark ? AppColors.darkSurface : AppColors.surface;
+    final borderColor = isDark ? AppColors.darkBorder : AppColors.border;
+
+    final location = offer.isOnSite
+        ? context.t('on_site')
+        : context.t('remote');
+    final when = _fmtDateTime(offer.dateTime);
+
+    // RepaintBoundary prevents this card from being repainted when the
+    // surrounding list scrolls or a neighbouring card changes state.
+    return RepaintBoundary(
+      child: Container(
+        padding: const EdgeInsets.fromLTRB(16, 14, 16, 14),
+        decoration: BoxDecoration(
+          color: surfaceColor,
+          borderRadius: BorderRadius.circular(14),
+          border: Border.all(color: borderColor),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                // Image thumbnail — wrapped in its own RepaintBoundary so the
+                // image load/fade-in does not trigger a repaint of the text area.
+                if (offer.imageUrl != null)
+                  RepaintBoundary(
+                    child: Padding(
+                      padding: const EdgeInsets.only(right: 12),
+                      child: ClipRRect(
+                        borderRadius: BorderRadius.circular(8),
+                        child: CachedNetworkImage(
+                          imageUrl: offer.imageUrl!,
+                          width: 48,
+                          height: 48,
+                          fit: BoxFit.cover,
+                          // Keeps a 160×160 px bitmap in RAM — not the
+                          // full-resolution image decoded from the network.
+                          memCacheWidth: 160,
+                          memCacheHeight: 160,
+                          // Limits what is persisted to the disk LRU cache.
+                          maxWidthDiskCache: 160,
+                          maxHeightDiskCache: 160,
+                          placeholder: (_, _) => Container(
+                            width: 48,
+                            height: 48,
+                            color: isDark
+                                ? AppColors.darkBorder
+                                : AppColors.border,
+                          ),
+                          errorWidget: (_, _, _) => Container(
+                            width: 48,
+                            height: 48,
+                            color: isDark
+                                ? AppColors.darkBorder
+                                : AppColors.border,
+                            child: const Icon(Icons.image_not_supported,
+                                size: 20, color: AppColors.greyText),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                Expanded(
+                  child: Text(offer.title,
+                      style: const TextStyle(
+                          fontSize: 18, fontWeight: FontWeight.w900)),
+                ),
+                OfferLifecycleBadge(offer: offer),
+                IconButton(
+                  icon: const Icon(Icons.edit_outlined, size: 20),
+                  color: AppColors.primaryYellow,
+                  tooltip: context.t('edit_offer'),
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => EditOfferPage(offer: offer),
+                      ),
+                    );
+                  },
+                ),
+                IconButton(
+                  icon: const Icon(Icons.delete_outline, size: 20),
+                  color: AppColors.danger,
+                  tooltip: context.t('delete_offer'),
+                  onPressed: () => _deleteOffer(context),
+                ),
+              ],
+            ),
+            const SizedBox(height: 6),
+            Text(
+              '${offer.category} • \$${offer.valueCop} COP',
+              style: const TextStyle(color: AppColors.greyText, fontSize: 15),
+            ),
+            const SizedBox(height: 6),
+            Text(
+              '$when • ${offer.durationHours}h • $location',
+              style: const TextStyle(color: AppColors.greyText, fontSize: 15),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ── Lifecycle badge ───────────────────────────────────────────────────────────
+
+class OfferLifecycleBadge extends StatelessWidget {
+  final OfferModel offer;
+  const OfferLifecycleBadge({super.key, required this.offer});
+
+  @override
+  Widget build(BuildContext context) {
+    final now = DateTime.now();
+    final (label, color, icon) = switch (offer.offerState) {
+      OfferState.upcoming => (
+          context.t('state_badge_upcoming'),
+          const Color(0xFF3B82F6),
+          Icons.schedule_outlined,
+        ),
+      OfferState.active when offer.endTime.difference(now).inHours < 24 => (
+          context.t('state_badge_closing_soon'),
+          const Color(0xFFF5A623),
+          Icons.warning_amber_rounded,
+        ),
+      OfferState.active => (
+          context.t('state_badge_active'),
+          AppColors.success,
+          Icons.circle,
+        ),
+      OfferState.closed => (
+          context.t('state_badge_closed'),
+          AppColors.greyText,
+          Icons.lock_outline,
+        ),
+    };
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 12, color: color),
+          const SizedBox(width: 4),
+          Text(
+            label,
+            style: TextStyle(
+              fontSize: 11,
+              fontWeight: FontWeight.w800,
+              color: color,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/flutter_application_goatly/lib/features/staff/create/staff_create_offers_page.dart
+++ b/flutter_application_goatly/lib/features/staff/create/staff_create_offers_page.dart
@@ -6,9 +6,8 @@ import '../../../app/localization.dart';
 import '../../../data/app_state.dart';
 import '../../../data/settings_state.dart';
 import '../../../models/offer_model.dart';
-import '../../../services/api_service.dart';
+import 'offer_card.dart';
 import 'offer_detail_page.dart';
-import 'edit_offer_page.dart';
 
 class StaffCreateOffersPage extends StatefulWidget {
   const StaffCreateOffersPage({super.key});
@@ -154,10 +153,24 @@ class _StaffCreateOffersPageState extends State<StaffCreateOffersPage> {
                   )
                 : ListView.builder(
                     padding: const EdgeInsets.fromLTRB(16, 8, 16, 120),
+                    // Keeps only 400 px of off-screen items painted at a time,
+                    // reducing GPU rasterisation work during fast flings.
+                    cacheExtent: 400.0,
+                    // Disable automatic KeepAlive — the analytics shell already
+                    // manages tab lifecycle; keeping all items alive wastes RAM.
+                    addAutomaticKeepAlives: false,
+                    // Flutter will wrap each item in a RepaintBoundary; combined
+                    // with the one inside OfferCard this is intentional double-
+                    // isolation: the ListView boundary catches layout changes and
+                    // the card boundary catches internal repaints.
+                    addRepaintBoundaries: true,
                     itemCount: filtered.length,
                     itemBuilder: (context, i) {
                       final o = filtered[i];
                       return Padding(
+                        // ValueKey lets Flutter diff the list efficiently when
+                        // items are reordered or removed.
+                        key: ValueKey(o.id),
                         padding: const EdgeInsets.only(bottom: 10),
                         child: InkWell(
                           borderRadius: BorderRadius.circular(14),
@@ -170,7 +183,7 @@ class _StaffCreateOffersPageState extends State<StaffCreateOffersPage> {
                               context.read<AppState>().loadOffersFromBackend();
                             }
                           },
-                          child: _OfferCard(offer: o, isDark: isDark),
+                          child: OfferCard(offer: o, isDark: isDark),
                         ),
                       );
                     },
@@ -245,200 +258,6 @@ class _EmptyOffers extends StatelessWidget {
             ),
           ],
         ),
-      ),
-    );
-  }
-}
-
-class _OfferCard extends StatelessWidget {
-  final OfferModel offer;
-  final bool isDark;
-
-  const _OfferCard({required this.offer, required this.isDark});
-
-  String _fmtDateTime(DateTime d) {
-    final mm = d.month.toString().padLeft(2, '0');
-    final dd = d.day.toString().padLeft(2, '0');
-    final hh = (d.hour % 12 == 0 ? 12 : d.hour % 12).toString();
-    final min = d.minute.toString().padLeft(2, '0');
-    final ampm = d.hour < 12 ? 'AM' : 'PM';
-    return '$mm/$dd ${hh.padLeft(2, '0')}:$min $ampm';
-  }
-
-  Future<void> _deleteOffer(BuildContext context) async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-        title: Text(context.t('delete_offer_confirm'),
-            style: const TextStyle(fontWeight: FontWeight.w800)),
-        content: Text(context.t('delete_offer_body')),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, false),
-            child: Text(context.t('cancel'),
-                style: const TextStyle(color: AppColors.greyText)),
-          ),
-          ElevatedButton(
-            style: ElevatedButton.styleFrom(
-              backgroundColor: AppColors.danger,
-              foregroundColor: Colors.white,
-              shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(10)),
-            ),
-            onPressed: () => Navigator.pop(ctx, true),
-            child: Text(context.t('delete'),
-                style: const TextStyle(fontWeight: FontWeight.w700)),
-          ),
-        ],
-      ),
-    );
-
-    if (confirmed != true || !context.mounted) return;
-
-    try {
-      await ApiService.deleteOffer(offer.id);
-      if (context.mounted) {
-        context.read<AppState>().removeOffer(offer.id);
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(context.t('offer_deleted')),
-            backgroundColor: AppColors.success,
-            behavior: SnackBarBehavior.floating,
-          ),
-        );
-      }
-    } catch (e) {
-      if (context.mounted) {
-        final msg = e is ApiException
-            ? e.message
-            : 'Sin conexión — no se pudo eliminar la oferta';
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(msg),
-            backgroundColor: AppColors.danger,
-            behavior: SnackBarBehavior.floating,
-          ),
-        );
-      }
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final surfaceColor = isDark ? AppColors.darkSurface : AppColors.surface;
-    final borderColor = isDark ? AppColors.darkBorder : AppColors.border;
-
-    final location = offer.isOnSite
-        ? context.t('on_site')
-        : context.t('remote');
-    final when = _fmtDateTime(offer.dateTime);
-
-    return Container(
-      padding: const EdgeInsets.fromLTRB(16, 14, 16, 14),
-      decoration: BoxDecoration(
-        color: surfaceColor,
-        borderRadius: BorderRadius.circular(14),
-        border: Border.all(color: borderColor),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              Expanded(
-                child: Text(offer.title,
-                    style: const TextStyle(
-                        fontSize: 18, fontWeight: FontWeight.w900)),
-              ),
-              _LifecycleBadge(offer: offer),
-              IconButton(
-                icon: const Icon(Icons.edit_outlined, size: 20),
-                color: AppColors.primaryYellow,
-                tooltip: context.t('edit_offer'),
-                onPressed: () {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (_) => EditOfferPage(offer: offer),
-                    ),
-                  );
-                },
-              ),
-              IconButton(
-                icon: const Icon(Icons.delete_outline, size: 20),
-                color: AppColors.danger,
-                tooltip: context.t('delete_offer'),
-                onPressed: () => _deleteOffer(context),
-              ),
-            ],
-          ),
-          const SizedBox(height: 6),
-          Text(
-            '${offer.category} • \$${offer.valueCop} COP',
-            style: const TextStyle(color: AppColors.greyText, fontSize: 15),
-          ),
-          const SizedBox(height: 6),
-          Text(
-            '$when • ${offer.durationHours}h • $location',
-            style: const TextStyle(color: AppColors.greyText, fontSize: 15),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _LifecycleBadge extends StatelessWidget {
-  final OfferModel offer;
-  const _LifecycleBadge({required this.offer});
-
-  @override
-  Widget build(BuildContext context) {
-    final now = DateTime.now();
-    final (label, color, icon) = switch (offer.offerState) {
-      OfferState.upcoming => (
-          context.t('state_badge_upcoming'),
-          const Color(0xFF3B82F6),
-          Icons.schedule_outlined,
-        ),
-      OfferState.active when offer.endTime.difference(now).inHours < 24 => (
-          context.t('state_badge_closing_soon'),
-          const Color(0xFFF5A623),
-          Icons.warning_amber_rounded,
-        ),
-      OfferState.active => (
-          context.t('state_badge_active'),
-          AppColors.success,
-          Icons.circle,
-        ),
-      OfferState.closed => (
-          context.t('state_badge_closed'),
-          AppColors.greyText,
-          Icons.lock_outline,
-        ),
-    };
-
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-      decoration: BoxDecoration(
-        color: color.withValues(alpha: 0.12),
-        borderRadius: BorderRadius.circular(20),
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(icon, size: 12, color: color),
-          const SizedBox(width: 4),
-          Text(
-            label,
-            style: TextStyle(
-              fontSize: 11,
-              fontWeight: FontWeight.w800,
-              color: color,
-            ),
-          ),
-        ],
       ),
     );
   }

--- a/flutter_application_goatly/lib/models/offer_model.dart
+++ b/flutter_application_goatly/lib/models/offer_model.dart
@@ -16,6 +16,7 @@ class OfferModel {
   final bool closedEarly;
   final String state; // 'upcoming' | 'active' | 'closed' from backend
   final DateTime createdAt;
+  final String? imageUrl; // optional offer thumbnail for list display
 
   OfferModel({
     required this.id,
@@ -33,6 +34,7 @@ class OfferModel {
     this.closedEarly = false,
     this.state = 'upcoming',
     required this.createdAt,
+    this.imageUrl,
   });
 
   /// Parsed enum for use in switch expressions.
@@ -61,6 +63,7 @@ class OfferModel {
         closedEarly: j['closed_early'] as bool? ?? false,
         state: j['state'] as String? ?? 'upcoming',
         createdAt: DateTime.parse(j['created_at'] as String),
+        imageUrl: j['image_url'] as String?,
       );
 
   Map<String, dynamic> toJson() => {

--- a/flutter_application_goatly/lib/services/api_service.dart
+++ b/flutter_application_goatly/lib/services/api_service.dart
@@ -499,6 +499,25 @@ class ApiService {
     }
     return jsonDecode(res.body) as Map<String, dynamic>;
   }
+
+  // ── BQ11 (Santiago Reyes) ─ Offer Lifecycle ────────────────────────────
+
+  /// GET /analytics/offer-lifecycle
+  /// BQ11: Average, min, max days an offer stays open + total closed offers.
+  static Future<Map<String, dynamic>> getOfferLifecycle() async {
+    final res = await http
+        .get(
+          Uri.parse('$baseUrl/analytics/offer-lifecycle'),
+          headers: _headers,
+        )
+        .timeout(const Duration(seconds: 10));
+
+    if (res.statusCode != 200) {
+      throw ApiException(
+          'Error al obtener ciclo de vida de ofertas (${res.statusCode})');
+    }
+    return jsonDecode(res.body) as Map<String, dynamic>;
+  }
 }
 
 class ApiException implements Exception {

--- a/flutter_application_goatly/pubspec.lock
+++ b/flutter_application_goatly/pubspec.lock
@@ -25,6 +25,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  cached_network_image:
+    dependency: "direct main"
+    description:
+      name: cached_network_image
+      sha256: "7c1183e361e5c8b0a0f21a28401eecdbde252441106a9816400dd4c2b2424916"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.1"
+  cached_network_image_platform_interface:
+    dependency: transitive
+    description:
+      name: cached_network_image_platform_interface
+      sha256: "35814b016e37fbdc91f7ae18c8caf49ba5c88501813f73ce8a07027a395e2829"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.1"
+  cached_network_image_web:
+    dependency: transitive
+    description:
+      name: cached_network_image_web
+      sha256: "980842f4e8e2535b8dbd3d5ca0b1f0ba66bf61d14cc3a17a9b4788a3685ba062"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.1"
   characters:
     dependency: transitive
     description:
@@ -161,11 +185,27 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.9.3+5"
+  fixnum:
+    dependency: transitive
+    description:
+      name: fixnum
+      sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   flutter:
     dependency: "direct main"
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_cache_manager:
+    dependency: transitive
+    description:
+      name: flutter_cache_manager
+      sha256: "400b6592f16a4409a7f2bb929a9a7e38c72cceb8ffb99ee57bbf2cb2cecf8386"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.1"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -552,6 +592,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "9.3.0"
+  octo_image:
+    dependency: transitive
+    description:
+      name: octo_image
+      sha256: "34faa6639a78c7e3cbe79be6f9f96535867e879748ade7d17c9b1ae7536293bd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   package_config:
     dependency: transitive
     description:
@@ -672,6 +720,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.0"
+  rxdart:
+    dependency: transitive
+    description:
+      name: rxdart
+      sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.28.0"
   sensors_plus:
     dependency: "direct main"
     description:
@@ -861,6 +917,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  uuid:
+    dependency: transitive
+    description:
+      name: uuid
+      sha256: "1fef9e8e11e2991bb773070d4656b7bd5d850967a2456cfc83cf47925ba79489"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.5.3"
   vector_math:
     dependency: transitive
     description:

--- a/flutter_application_goatly/pubspec.yaml
+++ b/flutter_application_goatly/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   path_provider: ^2.1.2
   sqflite: ^2.3.3+1
   path: ^1.9.0
+  cached_network_image: ^3.4.1
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
- New OfferLifecycleScreen with compute() isolate, 3-tier cache (LRU → Hive → SharedPreferences, key: bq11_offer_lifecycle), and offline banner with last-updated timestamp
- Add cached_network_image dependency; extract OfferCard with RepaintBoundary and CachedNetworkImage (memCache/diskCache 160px)
- ListView.builder: addAutomaticKeepAlives:false, cacheExtent:400, addRepaintBoundaries:true, ValueKey per item
- Wire BQ11 tab in AnalyticsShell; prefetch via Future.wait